### PR TITLE
Bug MAJ de l'UI lorsque l'on retire un abonné 

### DIFF
--- a/lib/data/ecogest_api_data_source.dart
+++ b/lib/data/ecogest_api_data_source.dart
@@ -10,7 +10,8 @@ class EcoGestApiDataSource {
 
   // to test on android emulator try this for HTTP request:
   // static const _baseUrl = "http://10.0.2.2:8080/api";
-  static const _baseUrl = "http://localhost:8080/api";
+  // static const _baseUrl = "http://localhost:8080/api";
+  static const _baseUrl = "https://ecogest.org/api";
 
   static get baseUrl {
     return _baseUrl;

--- a/lib/state_management/users_relation/users_relation_cubit.dart
+++ b/lib/state_management/users_relation/users_relation_cubit.dart
@@ -1,7 +1,6 @@
 import 'package:ecogest_front/services/users_relation_service.dart';
 import 'package:ecogest_front/state_management/users_relation/users_relation_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter/material.dart';	
 
 class UsersRelationCubit extends Cubit<UsersRelationState> {
   UsersRelationCubit() : super(UsersRelationStateInitial());
@@ -21,7 +20,6 @@ class UsersRelationCubit extends Cubit<UsersRelationState> {
   }
 
   Future<void> unSubscribe(int userId) async {
-    debugPrint("unSubscribe");
     try {
       emit(UsersRelationStateLoading());
       await UsersRelationService.unSubscribe(userId);
@@ -47,7 +45,6 @@ class UsersRelationCubit extends Cubit<UsersRelationState> {
   }
 
   Future<void> removeFollower(int userId) async {
-    debugPrint("removeFollower");
     try {
       emit(UsersRelationStateLoading());
       await UsersRelationService.removeFollower(userId);

--- a/lib/state_management/users_relation/users_relation_cubit.dart
+++ b/lib/state_management/users_relation/users_relation_cubit.dart
@@ -1,6 +1,7 @@
 import 'package:ecogest_front/services/users_relation_service.dart';
 import 'package:ecogest_front/state_management/users_relation/users_relation_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter/material.dart';	
 
 class UsersRelationCubit extends Cubit<UsersRelationState> {
   UsersRelationCubit() : super(UsersRelationStateInitial());
@@ -20,10 +21,11 @@ class UsersRelationCubit extends Cubit<UsersRelationState> {
   }
 
   Future<void> unSubscribe(int userId) async {
+    debugPrint("unSubscribe");
     try {
       emit(UsersRelationStateLoading());
       await UsersRelationService.unSubscribe(userId);
-      emit(UnSubscriptionStateSuccess());
+      emit(UnSubscriptionStateSuccess(userId));
     } catch (error) {
       emit(UsersRelationStateError("Erreur rencontrée. Veuillez réessayer."));
     }
@@ -45,10 +47,11 @@ class UsersRelationCubit extends Cubit<UsersRelationState> {
   }
 
   Future<void> removeFollower(int userId) async {
+    debugPrint("removeFollower");
     try {
       emit(UsersRelationStateLoading());
       await UsersRelationService.removeFollower(userId);
-      emit(RemoveFollowerStateSuccess());
+      emit(RemoveFollowerStateSuccess(userId));
     } catch (error) {
       emit(UsersRelationStateError("Erreur rencontrée. Veuillez réessayer."));
     }

--- a/lib/state_management/users_relation/users_relation_state.dart
+++ b/lib/state_management/users_relation/users_relation_state.dart
@@ -1,5 +1,4 @@
-abstract class UsersRelationState {
-}
+abstract class UsersRelationState {}
 
 class UsersRelationStateInitial extends UsersRelationState {}
 
@@ -9,7 +8,11 @@ class SubscriptionStateSuccess extends UsersRelationState {}
 
 class SubscriptionCancelStateSuccess extends UsersRelationState {}
 
-class UnSubscriptionStateSuccess extends UsersRelationState {}
+class UnSubscriptionStateSuccess extends UsersRelationState {
+  final int followingId;
+
+  UnSubscriptionStateSuccess(this.followingId);
+}
 
 class SubscriptionApproveOrDeclineStateSuccess extends UsersRelationState {}
 
@@ -23,4 +26,8 @@ class BlockStateSuccess extends UsersRelationState {}
 
 class UnBlockStateSuccess extends UsersRelationState {}
 
-class RemoveFollowerStateSuccess extends UsersRelationState {}
+class RemoveFollowerStateSuccess extends UsersRelationState {
+  final int followerId;
+
+  RemoveFollowerStateSuccess(this.followerId);
+}

--- a/lib/widgets/account/subscriptions_list_widget.dart
+++ b/lib/widgets/account/subscriptions_list_widget.dart
@@ -9,16 +9,16 @@ import 'package:ecogest_front/assets/ecogest_theme.dart';
 import 'package:go_router/go_router.dart';
 
 class SubscriptionsListWidget extends StatefulWidget {
-  SubscriptionsListWidget(
-      {super.key,
-      required this.subscriptions,
-      required this.isFollowerList,
-      required this.userId,
-      required this.isFollowing});
+  const SubscriptionsListWidget({
+    super.key,
+    required this.subscriptions,
+    required this.isFollowerList,
+    required this.userId,
+    required this.isFollowing,
+  });
 
   final int userId;
   final List<UsersRelationModel?> subscriptions;
-
   final bool isFollowerList;
   final bool isFollowing;
 
@@ -27,411 +27,157 @@ class SubscriptionsListWidget extends StatefulWidget {
 }
 
 class _SubscriptionsListWidget extends State<SubscriptionsListWidget> {
-  GlobalKey<RefreshIndicatorState> refreshIndicatorKey =
-      GlobalKey<RefreshIndicatorState>();
+  final GlobalKey<RefreshIndicatorState> refreshIndicatorKey = GlobalKey<RefreshIndicatorState>();
 
   @override
   Widget build(BuildContext context) {
-    final List<UsersRelationModel?> subscriptions = widget.subscriptions;
-    if (subscriptions.isEmpty) {
-      return Container(
-        padding: const EdgeInsets.all(16),
-        child: const Center(
-          child: Text('Oops rien à voir ici !'),
-        ),
-      );
-    }
     return BlocProvider<UsersRelationCubit>(
       create: (_) => UsersRelationCubit(),
-      child: Builder(builder: (context) {
-        return ListView.separated(
-          padding: const EdgeInsets.all(16),
-          separatorBuilder: (context, index) => const SizedBox(height: 0),
-          itemCount: subscriptions.length,
-          itemBuilder: (BuildContext context, int index) {
-            if (index < subscriptions.length) {
-              if (widget.isFollowerList) {
-                return BlocBuilder<UsersRelationCubit, UsersRelationState>(
-                    builder: (context, state) {
-                  if (context.read<UsersRelationCubit>().state
-                      is RemoveFollowerStateSuccess) {
-                    return const SizedBox.shrink();
-                  }
-                  return Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Row(
-                            children: [
-                              if (subscriptions[index]?.follower!.image !=
-                                  null) ...[
-                                CircleAvatar(
-                                  backgroundImage: NetworkImage(
-                                      subscriptions[index]!
-                                          .follower!
-                                          .image
-                                          .toString()),
-                                )
-                              ] else ...[
-                                const CircleAvatar(
-                                  child: Icon(Icons.person),
-                                ),
-                              ],
-                              const SizedBox(width: 16),
-                              GestureDetector(
-                                onTap: () {
-                                  GoRouter.of(context).push(
-                                      '/users/${subscriptions[index]!.followerId}');
-                                },
-                                child: Text(
-                                  subscriptions[index]
-                                          ?.follower
-                                          ?.username
-                                          ?.toString() ??
-                                      'Utilisateur inconnu',
-                                  style: const TextStyle(fontSize: 16),
-                                ),
-                              ),
-                            ],
-                          ),
-                          if (widget.userId ==
-                              context
-                                  .read<AuthenticationCubit>()
-                                  .state
-                                  .user!
-                                  .id) ...[
-                            FilledButton(
-                              style: FilledButton.styleFrom(
-                                backgroundColor: (context
-                                        .read<ThemeSettingsCubit>()
-                                        .state
-                                        .isDarkMode
-                                    ? darkColorScheme.primary
-                                    : lightColorScheme.primary),
-                                fixedSize: const Size(160, 50),
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(10.0),
-                                ),
-                              ),
-                              onPressed: () {
-                                context
-                                    .read<UsersRelationCubit>()
-                                    .removeFollower(
-                                        subscriptions[index]!.followerId!);
-                              },
-                              child: const Text(
-                                'Retirer',
-                                style: TextStyle(color: Colors.white),
-                              ),
-                            ),
-                          ] 
-                        ]),
-                  );
-                });
-              }
-              return BlocBuilder<UsersRelationCubit, UsersRelationState>(
-                builder: (context, state) {
-                  if (context.read<UsersRelationCubit>().state
-                      is SubscriptionStateSuccess) {
-                    return Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Row(
-                              children: [
-                                if (subscriptions[index]?.following!.image !=
-                                    null) ...[
-                                  CircleAvatar(
-                                    backgroundImage: NetworkImage(
-                                        subscriptions[index]!
-                                            .following!
-                                            .image
-                                            .toString()),
-                                  )
-                                ] else ...[
-                                  const CircleAvatar(
-                                    child: Icon(Icons.person),
-                                  ),
-                                ],
-                                const SizedBox(width: 16),
-                                GestureDetector(
-                                  onTap: () {
-                                    GoRouter.of(context).push(
-                                        '/users/${subscriptions[index]!.followingId}');
-                                  },
-                                  child: Text(
-                                    subscriptions[index]
-                                            ?.following
-                                            ?.username
-                                            ?.toString() ??
-                                        'Utilisateur inconnu',
-                                    style: const TextStyle(fontSize: 16),
-                                  ),
-                                ),
-                              ],
-                            ),
-                            if (widget.userId ==
-                                context
-                                    .read<AuthenticationCubit>()
-                                    .state
-                                    .user!
-                                    .id) ...[
-                              FilledButton(
-                                style: FilledButton.styleFrom(
-                                  backgroundColor: (Colors.white),
-                                  fixedSize: const Size(160, 50),
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(10.0),
-                                  ),
-                                ),
-                                onPressed: () {
-                                  context
-                                      .read<UsersRelationCubit>()
-                                      .subscription(
-                                          subscriptions[index]!.followingId!,
-                                          true);
-                                },
-                                child: const Text(
-                                  'Annuler',
-                                  style: TextStyle(color: Colors.black),
-                                ),
-                              ),
-                            ]
-                          ]),
-                    );
-                  }
-                  if (context.read<UsersRelationCubit>().state
-                      is UnSubscriptionStateSuccess) {
-                    return Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Row(
-                              children: [
-                                if (subscriptions[index]?.following!.image !=
-                                    null) ...[
-                                  CircleAvatar(
-                                    backgroundImage: NetworkImage(
-                                        subscriptions[index]!
-                                            .following!
-                                            .image
-                                            .toString()),
-                                  )
-                                ] else ...[
-                                  const CircleAvatar(
-                                    child: Icon(Icons.person),
-                                  ),
-                                ],
-                                const SizedBox(width: 16),
-                                GestureDetector(
-                                  onTap: () {
-                                    GoRouter.of(context).push(
-                                        '/users/${subscriptions[index]!.followingId}');
-                                  },
-                                  child: Text(
-                                    subscriptions[index]
-                                            ?.following
-                                            ?.username
-                                            ?.toString() ??
-                                        'Utilisateur inconnu',
-                                    style: const TextStyle(fontSize: 16),
-                                  ),
-                                ),
-                              ],
-                            ),
-                            if (widget.userId ==
-                                context
-                                    .read<AuthenticationCubit>()
-                                    .state
-                                    .user!
-                                    .id) ...[
-                              FilledButton(
-                                style: FilledButton.styleFrom(
-                                  backgroundColor: (context
-                                          .read<ThemeSettingsCubit>()
-                                          .state
-                                          .isDarkMode
-                                      ? darkColorScheme.primary
-                                      : lightColorScheme.primary),
-                                  fixedSize: const Size(160, 50),
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(10.0),
-                                  ),
-                                ),
-                                onPressed: () {
-                                  context
-                                      .read<UsersRelationCubit>()
-                                      .subscription(
-                                          subscriptions[index]!.followingId!,
-                                          false);
-                                },
-                                child: const Text(
-                                  'Me réabonner',
-                                  style: TextStyle(color: Colors.white),
-                                ),
-                              ),
-                            ]
-                          ]),
-                    );
-                  }
-                  if (context.read<UsersRelationCubit>().state
-                      is SubscriptionCancelStateSuccess) {
-                    return Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Row(
-                              children: [
-                                if (subscriptions[index]?.following!.image !=
-                                    null) ...[
-                                  CircleAvatar(
-                                    backgroundImage: NetworkImage(
-                                        subscriptions[index]!
-                                            .following!
-                                            .image
-                                            .toString()),
-                                  )
-                                ] else ...[
-                                  const CircleAvatar(
-                                    child: Icon(Icons.person),
-                                  ),
-                                ],
-                                const SizedBox(width: 16),
-                                GestureDetector(
-                                  onTap: () {
-                                    GoRouter.of(context).push(
-                                        '/users/${subscriptions[index]!.followingId}');
-                                  },
-                                  child: Text(
-                                    subscriptions[index]
-                                            ?.following
-                                            ?.username
-                                            ?.toString() ??
-                                        'Utilisateur inconnu',
-                                    style: const TextStyle(fontSize: 16),
-                                  ),
-                                ),
-                              ],
-                            ),
-                            if (widget.userId ==
-                                context
-                                    .read<AuthenticationCubit>()
-                                    .state
-                                    .user!
-                                    .id) ...[
-                              FilledButton(
-                                style: FilledButton.styleFrom(
-                                  backgroundColor: (context
-                                          .read<ThemeSettingsCubit>()
-                                          .state
-                                          .isDarkMode
-                                      ? darkColorScheme.primary
-                                      : lightColorScheme.primary),
-                                  fixedSize: const Size(160, 50),
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(10.0),
-                                  ),
-                                ),
-                                onPressed: () {
-                                  context
-                                      .read<UsersRelationCubit>()
-                                      .subscription(
-                                          subscriptions[index]!.followingId!,
-                                          false);
-                                },
-                                child: const Text(
-                                  'M\'abonner',
-                                  style: TextStyle(color: Colors.white),
-                                ),
-                              ),
-                            ]
-                          ]),
-                    );
-                  }
-                  return Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Row(
-                            children: [
-                              if (subscriptions[index]?.following!.image !=
-                                  null) ...[
-                                CircleAvatar(
-                                  backgroundImage: NetworkImage(
-                                      subscriptions[index]!
-                                          .following!
-                                          .image
-                                          .toString()),
-                                )
-                              ] else ...[
-                                const CircleAvatar(
-                                  child: Icon(Icons.person),
-                                ),
-                              ],
-                              const SizedBox(width: 16),
-                              GestureDetector(
-                                onTap: () {
-                                  GoRouter.of(context).push(
-                                      '/users/${subscriptions[index]!.followingId}');
-                                },
-                                child: Text(
-                                  subscriptions[index]
-                                          ?.following
-                                          ?.username
-                                          ?.toString() ??
-                                      'Utilisateur inconnu',
-                                  style: const TextStyle(fontSize: 16),
-                                ),
-                              ),
-                            ],
-                          ),
-                          if (widget.userId ==
-                              context
-                                  .read<AuthenticationCubit>()
-                                  .state
-                                  .user!
-                                  .id) ...[
-                         FilledButton(
-                                style: FilledButton.styleFrom(
-                                  backgroundColor: (Colors.white),
-                                  fixedSize: const Size(160, 50),
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(10.0),
-                                  ),
-                                ),
-                                onPressed: () {
-                                  context
-                                      .read<UsersRelationCubit>()
-                                      .unSubscribe(
-                                          subscriptions[index]!.followingId!
-                                      );
-                                },
-                                child: const Text(
-                                  'Me désabonner',
-                                  style: TextStyle(color: Colors.black),
-                                ),
-                              ),
-                          ]
-                        ]),
-                  );
-                },
-              );
-            }
+      child: BlocConsumer<UsersRelationCubit, UsersRelationState>(
+        listener: (context, state) {
+          if (state is RemoveFollowerStateSuccess) {
+            setState(() {
+              widget.subscriptions.removeWhere((subscription) =>
+                  widget.isFollowerList && subscription?.followerId == state.followerId);
+            });
+          }
+          if (state is UnSubscriptionStateSuccess) {
+            setState(() {
+              widget.subscriptions.removeWhere((subscription) =>
+                  !widget.isFollowerList && subscription?.followingId == state.followingId);
+            });
+          }
+        },
+        builder: (context, state) {
+          final List<UsersRelationModel?> subscriptions = widget.subscriptions;
+
+          if (subscriptions.isEmpty) {
             return Container(
               padding: const EdgeInsets.all(16),
               child: const Center(
                 child: Text('Oops rien à voir ici !'),
               ),
             );
-          },
-          // Listen to scroll events in the goal to load more posts
-        );
-      }),
+          }
+
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            separatorBuilder: (context, index) => const SizedBox(height: 16),
+            itemCount: subscriptions.length,
+            itemBuilder: (BuildContext context, int index) {
+              return SubscriptionItem(
+                subscription: subscriptions[index],
+                isFollowerList: widget.isFollowerList,
+                userId: widget.userId,
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class SubscriptionItem extends StatelessWidget {
+  const SubscriptionItem({
+    Key? key,
+    required this.subscription,
+    required this.isFollowerList,
+    required this.userId,
+  }) : super(key: key);
+
+  final UsersRelationModel? subscription;
+  final bool isFollowerList;
+  final int userId;
+
+  @override
+  Widget build(BuildContext context) {
+    if (subscription == null) return SizedBox.shrink();
+
+    final themeCubit = context.read<ThemeSettingsCubit>();
+    final authCubit = context.read<AuthenticationCubit>();
+
+    final isCurrentUser = userId == authCubit.state.user?.id;
+    final primaryColor = themeCubit.state.isDarkMode
+        ? darkColorScheme.primary
+        : lightColorScheme.primary;
+
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Row(
+            children: [
+              if (subscriptionImage() != null) ...[
+                CircleAvatar(
+                  backgroundImage: NetworkImage(subscriptionImage()!),
+                )
+              ] else ...[
+                const CircleAvatar(
+                  child: Icon(Icons.person),
+                ),
+              ],
+              const SizedBox(width: 16),
+              GestureDetector(
+                onTap: () {
+                  GoRouter.of(context).push(
+                      '/users/${isFollowerList ? subscription!.followerId : subscription!.followingId}');
+                },
+                child: Text(
+                  subscriptionUsername(),
+                  style: const TextStyle(fontSize: 16),
+                ),
+              ),
+            ],
+          ),
+          if (isCurrentUser)
+            actionButton(context, primaryColor),
+        ],
+      ),
+    );
+  }
+
+  String? subscriptionImage() {
+    final imageUrl = isFollowerList
+        ? subscription?.follower?.image
+        : subscription?.following?.image;
+
+    return imageUrl?.toString();
+  }
+
+  String subscriptionUsername() {
+    final username = isFollowerList
+        ? subscription?.follower?.username
+        : subscription?.following?.username;
+
+    return username ?? 'Utilisateur inconnu';
+  }
+
+  Widget actionButton(BuildContext context, Color primaryColor) {
+    final buttonText = isFollowerList ? 'Retirer' : 'Me désabonner';
+    final buttonColor = primaryColor;
+    final textColor = Colors.white;
+
+    return FilledButton(
+      style: FilledButton.styleFrom(
+        backgroundColor: buttonColor,
+        fixedSize: const Size(160, 50),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10.0),
+        ),
+      ),
+      onPressed: () {
+        if (isFollowerList) {
+          context.read<UsersRelationCubit>().removeFollower(subscription!.followerId!);
+        } else {
+          context.read<UsersRelationCubit>().unSubscribe(subscription!.followingId!);
+        }
+      },
+      child: Text(
+        buttonText,
+        style: TextStyle(color: textColor),
+      ),
     );
   }
 }


### PR DESCRIPTION
usecase : la vue ne se mettait pas à jours lors de la suppression d'un abonné (clique sur le bouton retirer sur la vue des abonnées et abonnements) 

**solution :** 
Ajout de propriétés à l'état (user_relation_state) :
- A été ajouté followerId à RemoveFollowerStateSuccess et followingId à UnSubscriptionStateSuccess pour pouvoir identifier quel abonnement a été mis à jour.

Utilisation de BlocConsumer au lieu de BlocBuilder (subscriptions_list_widget.dart / l.38) :
- BlocConsumer permet à la fois d'écouter les changements d'état et de reconstruire l'interface utilisateur. Cela nous permet de mettre à jour la liste des abonnements dans la méthode listener et de reconstruire l'interface utilisateur dans la méthode builder.