### PR TITLE
BUG et UI profil 

### DIFF
--- a/lib/data/ecogest_api_data_source.dart
+++ b/lib/data/ecogest_api_data_source.dart
@@ -10,8 +10,8 @@ class EcoGestApiDataSource {
 
   // to test on android emulator try this for HTTP request:
   // static const _baseUrl = "http://10.0.2.2:8080/api";
-  static const _baseUrl = "http://localhost:8080/api";
-  // static const _baseUrl = "https://ecogest.org/api";
+  //static const _baseUrl = "http://localhost:8080/api";
+ static const _baseUrl = "https://ecogest.org/api";
 
 
   static get baseUrl {

--- a/lib/views/users/account_view.dart
+++ b/lib/views/users/account_view.dart
@@ -30,9 +30,8 @@ class _AccountViewState extends State<AccountView>
       GlobalKey<RefreshIndicatorState>();
 
   Future<void> refreshData() async {
-    setState(() {
-      context.read<AuthenticationCubit>().getCurrentUser();
-    });
+    await context.read<AuthenticationCubit>().getCurrentUser();
+    setState(() {});
   }
 
   @override
@@ -107,7 +106,7 @@ class _AccountViewState extends State<AccountView>
                           isBlocked: false,
                         ),
                         const SizedBox(height: 20),
-                        // New Widget: Account Trophies
+                        // Account Trophies
                         AccountTrophies(
                           userId: user.id!,
                         ),

--- a/lib/views/users/trophies_view.dart
+++ b/lib/views/users/trophies_view.dart
@@ -62,7 +62,6 @@ class TrophiesView extends StatelessWidget {
               text: TextSpan(
                 style: const TextStyle(
                   fontSize: 16,
-                  color: Colors.black,
                 ),
                 children: [
                   TextSpan(

--- a/lib/views/users/trophies_view.dart
+++ b/lib/views/users/trophies_view.dart
@@ -76,9 +76,9 @@ class TrophiesView extends StatelessWidget {
                       style: const TextStyle(
                         fontWeight: FontWeight.normal,
                       ),
-                      maxLines: 2, // Maximum 2 lines
-                      overflow: TextOverflow.ellipsis, // Handle overflow with ellipsis
-                      softWrap: true, // Allow text to wrap to the next line
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      softWrap: true, 
                     ),
                   ),
                 ],

--- a/lib/views/users/trophies_view.dart
+++ b/lib/views/users/trophies_view.dart
@@ -57,26 +57,33 @@ class TrophiesView extends StatelessWidget {
           ),
           const SizedBox(width: 16),
           // Right: Text
-          RichText(
-            text: TextSpan(
-              style: const TextStyle(
-                fontSize: 16,
-                color: Colors.black,
+          Expanded(
+            child: RichText(
+              text: TextSpan(
+                style: const TextStyle(
+                  fontSize: 16,
+                  color: Colors.black,
+                ),
+                children: [
+                  TextSpan(
+                    text: '$count X ',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  WidgetSpan(
+                    child: Text(
+                      _getCategoryName(categoryId),
+                      style: const TextStyle(
+                        fontWeight: FontWeight.normal,
+                      ),
+                      maxLines: 2, // Maximum 2 lines
+                      overflow: TextOverflow.ellipsis, // Handle overflow with ellipsis
+                      softWrap: true, // Allow text to wrap to the next line
+                    ),
+                  ),
+                ],
               ),
-              children: [
-                TextSpan(
-                  text: '$count X ',
-                  style: const TextStyle(
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                TextSpan(
-                  text: _getCategoryName(categoryId),
-                  style: const TextStyle(
-                    fontWeight: FontWeight.normal,
-                  ),
-                ),
-              ],
             ),
           ),
         ],
@@ -105,17 +112,20 @@ class TrophiesView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: const ThemeAppBar(title: 'Trophées'),
-        bottomNavigationBar: const AppBarFooter(),
-        body: SingleChildScrollView(
-          child: Stack(children: [
+      appBar: const ThemeAppBar(title: 'Trophées'),
+      bottomNavigationBar: const AppBarFooter(),
+      body: SingleChildScrollView(
+        child: Stack(
+          children: [
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 26.0),
               child: Column(
                 children: _buildTrophyItems(trophies),
               ),
             ),
-          ]),
-        ));
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/widgets/account/account_infos.dart
+++ b/lib/widgets/account/account_infos.dart
@@ -202,7 +202,7 @@ class _AccountInfo extends State<AccountInfo>
             const SizedBox(height: 16),
             // ... Third Bloc: Profil Bio ...
             Text(
-              user.biography ?? 'Default Biography',
+              user.biography ?? '',
               style: const TextStyle(fontSize: 16),
             ),
           ],

--- a/lib/widgets/account/account_infos.dart
+++ b/lib/widgets/account/account_infos.dart
@@ -55,8 +55,8 @@ class _AccountInfo extends State<AccountInfo>
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Container(
-                  width: 120,
-                  height: 120,
+                  width: 86,
+                  height: 86,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
                     image: DecorationImage(
@@ -74,15 +74,13 @@ class _AccountInfo extends State<AccountInfo>
                     Text(
                       user.username ?? 'Username',
                       style: const TextStyle(
-                          fontSize: 20, fontWeight: FontWeight.bold),
+                          fontSize: 18, fontWeight: FontWeight.bold),
                     ),
                     Text(
                       user.position ?? 'Le Monde',
-                      style: const TextStyle(fontSize: 16),
                     ),
                     const SizedBox(
-                      height: 6,
-                      width: 4,
+                      height: 2,
                     ),
                     Container(
                       padding: const EdgeInsets.symmetric(
@@ -99,7 +97,7 @@ class _AccountInfo extends State<AccountInfo>
                       child: Text(
                         user.badgeTitle ?? 'Badge',
                         style: TextStyle(
-                          fontSize: 14,
+                          fontSize: 12,
                           color: context.read<ThemeSettingsCubit>().state.isDarkMode
                                 ? darkColorScheme.onSecondaryContainer
                                 : lightColorScheme.onSecondaryContainer,


### PR DESCRIPTION
This PR addresses several issues in the application:

1. **Fixed Trophy Titles Overflowing**:
   - Long trophy titles were overflowing outside the frame. They are now properly handled to display on two lines if necessary.

2. **Gray Screen After Refreshing Profile**:
   - After editing the profile and changing the profile picture, pulling down to refresh the profile page resulted in a gray screen. This issue has been fixed, ensuring the profile page reloads correctly.

3. **Avatar Size Adjustment**:
   - The avatar size was still too large. It has been adjusted to a more appropriate size.

4. **Dark Mode Text Visibility on Trophy View**:
   - In dark mode, the text on the "My Trophies" view was black on a black background, making it unreadable. The text color has been corrected to ensure it is visible in dark mode.
